### PR TITLE
Update avn-api version

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "@polkadot/util": "5.9.2",
     "@polkadot/util-crypto": "5.9.2",
     "@alephium/sdk": "0.2.2",
-    "avn-api": "0.8.1",
+    "avn-api": "0.8.2",
     "axios": "0.21.1",
     "bignumber": "^1.1.0",
     "bignumber.js": "9.0.1",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "@polkadot/util": "5.9.2",
     "@polkadot/util-crypto": "5.9.2",
     "@alephium/sdk": "0.2.2",
-    "avn-api": "0.8.0",
+    "avn-api": "0.8.1",
     "axios": "0.21.1",
     "bignumber": "^1.1.0",
     "bignumber.js": "9.0.1",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "@polkadot/util": "5.9.2",
     "@polkadot/util-crypto": "5.9.2",
     "@alephium/sdk": "0.2.2",
-    "avn-api": "0.6.0",
+    "avn-api": "0.8.0",
     "axios": "0.21.1",
     "bignumber": "^1.1.0",
     "bignumber.js": "9.0.1",


### PR DESCRIPTION
This is a non-breaking change version with no public interface changes. It will re-enable staking functionality.